### PR TITLE
更新"".join(list)答案的描述

### DIFF
--- a/contents/qa-string.md
+++ b/contents/qa-string.md
@@ -1,4 +1,3 @@
-
 ### 为什么是string.join(list)而不是list.join(string)
 
 问题 [链接](http://stackoverflow.com/questions/493819/python-join-why-is-it-string-joinlist-instead-of-list-joinstring)
@@ -9,7 +8,7 @@
 
 答案：
 
-因为所有可迭代对象都可以被连接，但是连接者总是字符串
+因为所有可迭代对象都可以被连接，而不只是列表，但是连接者总是字符串
 
 ### 字符如何转为小写
 


### PR DESCRIPTION
> ### 为什么是string.join(list)而不是list.join(string)
> 
> 问题 [链接](http://stackoverflow.com/questions/493819/python-join->why-is-it-string-joinlist-instead-of-list-joinstring)
> 
>   my_list = ["Hello", "world"]
>    print "-".join(my_list)
>    #为什么不是 my_list.join("-") 。。。。这个....
> 
> 答案：
> 
> 因为所有可迭代对象都可以被连接，但是连接者总是字符串

---

答案是不是改成这样会好一些:  

> 因为所有可迭代对象都可以被连接，而不只是列表，但是连接者总是字符串   

虽然看起来差不多，感觉这样会更明确一些.
